### PR TITLE
Fix malformed testcase output w/ Backgrounds

### DIFF
--- a/lib/ci/reporter/cucumber.rb
+++ b/lib/ci/reporter/cucumber.rb
@@ -55,6 +55,7 @@ module CI
       end
 
       def before_background(*args)
+        @scenario = 'Background'
       end
 
       def after_background(*args)


### PR DESCRIPTION
Background sections trigger `before_steps`, which causes a `<testcase>` element without a name.  This makes it invalid for the jenkins JUnit plugin to process properly.