### PR TITLE
Fix malformed testcase output w/ Backgrounds

### DIFF
--- a/lib/ci/reporter/cucumber.rb
+++ b/lib/ci/reporter/cucumber.rb
@@ -55,6 +55,7 @@ module CI
       end
 
       def before_background(*args)
+        @scenario = 'Background'
       end
 
       def after_background(*args)


### PR DESCRIPTION
Background sections trigger `before_steps`, which causes a `<testcase>` element without a name.  This makes it invalid for the jenkins JUnit plugin to process properly.

I don't know whether this merge request has been tried before (the previous PR was not showing up for me locally using hub) but I thought I'd try it now, in part to further my own knowledge of git. 

````
git clone git@github.com:compwron/ci_reporter_cucumber.git
cd ci_reporter_cucumber/
git remote add jkrall git@github.com:jkrall/ci_reporter_cucumber.git
git remote update
git merge remotes/jkrall/master
git push
````
