### PR TITLE
Mark skipped tests as skipped

### DIFF
--- a/lib/ci/reporter/cucumber.rb
+++ b/lib/ci/reporter/cucumber.rb
@@ -80,8 +80,10 @@ module CI
         case steps.status
         when :pending, :undefined
           @test_case.name = "#{@test_case.name} (PENDING)"
+          @test_case.skipped = true
         when :skipped
           @test_case.name = "#{@test_case.name} (SKIPPED)"
+          @test_case.skipped = true
         when :failed
           @test_case.failures << CucumberFailure.new(steps)
         end

--- a/spec/ci/reporter/cucumber_spec.rb
+++ b/spec/ci/reporter/cucumber_spec.rb
@@ -121,21 +121,24 @@ module CI::Reporter
           expect(testcases.first).to eql test_case
         end
 
-        it "alters the name of a test case that is pending to include '(PENDING)'" do
+        it "skips and alters the name of a test case that is pending to include '(PENDING)'" do
           allow(step).to receive(:status).and_return(:pending)
           expect(test_case).to receive(:name=).with("Step Name (PENDING)")
+          expect(test_case).to receive(:skipped=).with(true)
           cucumber.after_steps(step)
         end
 
-        it "alters the name of a test case that is undefined to include '(PENDING)'" do
+        it "skips and alters the name of a test case that is undefined to include '(PENDING)'" do
           allow(step).to receive(:status).and_return(:undefined)
           expect(test_case).to receive(:name=).with("Step Name (PENDING)")
+          expect(test_case).to receive(:skipped=).with(true)
           cucumber.after_steps(step)
         end
 
-        it "alter the name of a test case that was skipped to include '(SKIPPED)'" do
+        it "skips and alters the name of a test case that was skipped to include '(SKIPPED)'" do
           allow(step).to receive(:status).and_return(:skipped)
           expect(test_case).to receive(:name=).with("Step Name (SKIPPED)")
+          expect(test_case).to receive(:skipped=).with(true)
           cucumber.after_steps(step)
         end
       end


### PR DESCRIPTION
Attempting to fix #6 -- mark skipped tests as skipped (instead of only renaming them).

I've tested this on our local Jenkins. The test (the first in the list) is marked as skipped:

![screen shot 2015-11-02 at 16 53 17](https://cloud.githubusercontent.com/assets/206108/10886584/f332a53a-8182-11e5-863b-888e0800c42b.png)
