### PR TITLE
Add option to let test cases with pending/undefined steps fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ task :cucumber => 'ci:setup:cucumber'
 
 ### Advanced usage
 
+If you want to treat `undefined` and `pending` steps as failures (instead of skipping them), set the `CI_PENDING_IS_FAILURE` environment variable to `true`.
+
 Refer to the shared [documentation][ci] for details on setting up
 CI::Reporter.
 

--- a/lib/ci/reporter/cucumber.rb
+++ b/lib/ci/reporter/cucumber.rb
@@ -74,12 +74,20 @@ module CI
         @test_case.start
       end
 
+      def treat_pending_as_failure?
+        ENV['CI_PENDING_IS_FAILURE'] == 'true'
+      end
+
       def after_steps(steps)
         @test_case.finish
 
         case steps.status
         when :pending, :undefined
-          @test_case.name = "#{@test_case.name} (PENDING)"
+          if treat_pending_as_failure?
+            @test_case.failures << CucumberFailure.new(steps)
+          else
+            @test_case.name = "#{@test_case.name} (PENDING)"
+          end
         when :skipped
           @test_case.name = "#{@test_case.name} (SKIPPED)"
         when :failed

--- a/spec/ci/reporter/cucumber_spec.rb
+++ b/spec/ci/reporter/cucumber_spec.rb
@@ -106,6 +106,7 @@ module CI::Reporter
 
       context "after steps" do
         before :each do
+          allow(cucumber).to receive(:treat_pending_as_failure?).and_return(false)
           cucumber.before_steps(step)
         end
 
@@ -137,6 +138,33 @@ module CI::Reporter
           allow(step).to receive(:status).and_return(:skipped)
           expect(test_case).to receive(:name=).with("Step Name (SKIPPED)")
           cucumber.after_steps(step)
+        end
+
+        context "when treating undefined/pending steps as failures" do
+          let(:failures) { [] }
+          let(:cucumber_failure) { double("cucumber_failure") }
+
+          before :each do
+            allow(cucumber).to receive(:treat_pending_as_failure?).and_return(true)
+            allow(test_case).to receive(:failures).and_return(failures)
+            allow(CI::Reporter::CucumberFailure).to receive(:new).and_return(cucumber_failure)
+          end
+
+          it "creates a new cucumber failure with a pending step" do
+            allow(step).to receive(:status).and_return(:pending)
+            expect(failures).to be_empty
+            cucumber.after_steps(step)
+            expect(failures).to_not be_empty
+            expect(failures.first).to eql cucumber_failure
+          end
+
+          it "creates a new cucumber failure with an undefined step" do
+            allow(step).to receive(:status).and_return(:undefined)
+            expect(failures).to be_empty
+            cucumber.after_steps(step)
+            expect(failures).to_not be_empty
+            expect(failures.first).to eql cucumber_failure
+          end
         end
       end
 


### PR DESCRIPTION
Introduces the environment variable `CI_PENDING_IS_FAILURE`. If set to
`true` test cases with pending steps will be marked as failures (instead
of being skipped).
When the environment variable is not given, it defaults to the old
behaviour of skipping those test cases to stay compatible.

I've tested this option on our Jenkins server. It picks up the pending test (the first test in the screenshot) and marks it as failure (instead of renaming it):
![screen shot 2015-11-02 at 16 57 18](https://cloud.githubusercontent.com/assets/206108/10907063/18575096-8227-11e5-9bd0-fd56bc0c4b40.png)
