### PR TITLE
Add option to let test cases with pending/undefined steps fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ task :cucumber => 'ci:setup:cucumber'
 
 ### Advanced usage
 
+If you want to treat `undefined` and `pending` steps as failures
+(instead of skipping them), set the `CI_PENDING_IS_FAILURE`
+environment variable to `true`.
+
 Refer to the shared [documentation][ci] for details on setting up
 CI::Reporter.
 

--- a/lib/ci/reporter/cucumber.rb
+++ b/lib/ci/reporter/cucumber.rb
@@ -74,13 +74,21 @@ module CI
         @test_case.start
       end
 
+      def treat_pending_as_failure?
+        ENV['CI_PENDING_IS_FAILURE'] == 'true'
+      end
+
       def after_steps(steps)
         @test_case.finish
 
         case steps.status
         when :pending, :undefined
-          @test_case.name = "#{@test_case.name} (PENDING)"
-          @test_case.skipped = true
+          if treat_pending_as_failure?
+            @test_case.failures << CucumberFailure.new(steps)
+          else
+            @test_case.name = "#{@test_case.name} (PENDING)"
+            @test_case.skipped = true
+          end
         when :skipped
           @test_case.name = "#{@test_case.name} (SKIPPED)"
           @test_case.skipped = true


### PR DESCRIPTION
Introduces the environment variable `CI_PENDING_IS_FAILURE`.

If set to `true`, test cases with pending steps will be marked as
failues instead of being skipped.

When the environment variable is not given, it defaults to the old
behaviour of skipping those test cases to stay compatible.