### PR TITLE
Handle data tables

### DIFF
--- a/acceptance/cucumber/cucumber_example.feature
+++ b/acceptance/cucumber/cucumber_example.feature
@@ -21,3 +21,23 @@ Feature: Example Cucumber feature
     Given that I can't code for peanuts
     And I write step definitions that throw exceptions
     Then I shouldn't be allowed out in public
+
+  Scenario: Using a data table in a scenario
+    Given that I want to include the following data table
+      | Data Column 1 | Data Column 2 | Data Column 3 |
+      | Data Cell A   | Data Cell B   | Data Cell C   |
+      | Data Cell D   | Data Cell E   | Data Cell F   |
+    Then I should not see each row in the table treated as a separate example
+
+  Scenario Outline: Using a scenario outline
+    Given that I might use a scenario outline with a data table and an examples table
+    And that I want to include the following data table
+      | Data Column 4 | Data Column 5 | Data Column 6 |
+      | Data Cell G   | Data Cell H   | Data Cell I   |
+      | Data Cell J   | Data Cell K   | Data Cell L   |
+    Then I want values for <Example Column 1>, <Example Column 2>, and <Example Column 3>
+
+    Examples:
+      | Example Column 1 | Example Column 2 | Example Column 3 |
+      | Example Cell A   | Example Cell B   | Example Cell C   |
+      | Example Cell D   | Example Cell E   | Example Cell F   |

--- a/acceptance/cucumber/step_definitions/development_steps.rb
+++ b/acceptance/cucumber/step_definitions/development_steps.rb
@@ -32,3 +32,19 @@ end
 
 Then /^I shouldn't be allowed out in public$/ do
 end
+
+Given /^that I want to include the following data table$/ do |table|
+  expect(table).to be_a(Cucumber::Ast::Table)
+end
+
+Then /^I should not see each row in the table treated as a separate example$/ do
+end
+
+Given /^that I might use a scenario outline with a data table and an examples table$/ do
+end
+
+Then /^I want values for (.*), (.*), and (.*)$/ do |arg_1, arg_2, arg_3|
+  expect(arg_1).to be_a(String)
+  expect(arg_2).to be_a(String)
+  expect(arg_3).to be_a(String)
+end

--- a/acceptance/verification_spec.rb
+++ b/acceptance/verification_spec.rb
@@ -17,7 +17,7 @@ describe "Cucumber acceptance" do
     it { is_expected.to have(0).errors }
     it { expect(result.skipped_count).to be 1 }
     it { is_expected.to have(2).failures }
-    it { is_expected.to have(4).testcases }
+    it { is_expected.to have(7).testcases }
 
     it_behaves_like "a report with consistent attribute counts"
     it_behaves_like "assertions are not tracked"
@@ -54,6 +54,35 @@ describe "Cucumber acceptance" do
         it "has a type" do
           expect(failure.type).to match /RuntimeError/
         end
+      end
+    end
+
+    describe "the test that uses a data table" do
+      subject(:testcase) { result.testcase('Using a data table in a scenario') }
+
+      it { is_expected.to have(0).failures }
+    end
+
+    context "the scenario outline with an examples table" do
+
+      let(:scenario_name) { 'Using a scenario outline' }
+      let(:example_1_string) { '| Example Cell A | Example Cell B | Example Cell C |' }
+      let(:example_2_string) { '| Example Cell D | Example Cell E | Example Cell F |' }
+
+      describe "the first example in the table" do
+        subject(:testcase) {
+          result.testcase("#{scenario_name} (outline: #{example_1_string})")
+        }
+
+        it { is_expected.to have(0).failures }
+      end
+
+      describe "the second example in the table" do
+        subject(:testcase) {
+          result.testcase("#{scenario_name} (outline: #{example_2_string})")
+        }
+
+        it { is_expected.to have(0).failures }
       end
     end
   end

--- a/lib/ci/reporter/cucumber.rb
+++ b/lib/ci/reporter/cucumber.rb
@@ -112,10 +112,7 @@ module CI
         # check multiple versions of the row and try to find the best fit
 
         if row.respond_to?(:scenario_outline) && !@header_row
-          outline = (row.respond_to? :name)             ? row.name :
-                    (row.respond_to? :scenario_outline) ? row.scenario_outline :
-                                                          row.to_s
-          @test_case = TestCase.new("#@scenario (outline: #{outline})")
+          @test_case = TestCase.new("#@scenario (outline: #{row.name})")
           @test_case.start
         end
       end

--- a/lib/ci/reporter/cucumber.rb
+++ b/lib/ci/reporter/cucumber.rb
@@ -73,6 +73,16 @@ module CI
         @feature_element = nil
       end
 
+      def feature_element_type
+        if @feature_element.instance_of?(::Cucumber::Ast::Scenario)
+          return :scenario
+        elsif @feature_element.instance_of?(::Cucumber::Ast::ScenarioOutline)
+          return :scenario_outline
+        else
+          return :unknown
+        end
+      end
+
       def scenario_name(keyword, name, *args)
         @scenario = (name || "Unnamed scenario").split("\n").first
       end

--- a/lib/ci/reporter/cucumber.rb
+++ b/lib/ci/reporter/cucumber.rb
@@ -110,11 +110,14 @@ module CI
       def before_table_row(table_row)
         row = table_row # shorthand for table_row
         # check multiple versions of the row and try to find the best fit
-        outline = (row.respond_to? :name)             ? row.name :
-                  (row.respond_to? :scenario_outline) ? row.scenario_outline :
-                                                        row.to_s
-        @test_case = TestCase.new("#@scenario (outline: #{outline})")
-        @test_case.start
+
+        if row.respond_to? :scenario_outline
+          outline = (row.respond_to? :name)             ? row.name :
+                    (row.respond_to? :scenario_outline) ? row.scenario_outline :
+                                                          row.to_s
+          @test_case = TestCase.new("#@scenario (outline: #{outline})")
+          @test_case.start
+        end
       end
 
       def after_table_row(table_row)
@@ -122,11 +125,14 @@ module CI
           @header_row = false
           return
         end
-        @test_case.finish
-        if table_row.respond_to? :failed?
-          @test_case.failures << CucumberFailure.new(table_row) if table_row.failed?
-          test_suite.testcases << @test_case
-          @test_case = nil
+
+        if table_row.respond_to?(:scenario_outline)
+          @test_case.finish
+          if table_row.respond_to? :failed?
+            @test_case.failures << CucumberFailure.new(table_row) if table_row.failed?
+            test_suite.testcases << @test_case
+            @test_case = nil
+          end
         end
       end
     end

--- a/lib/ci/reporter/cucumber.rb
+++ b/lib/ci/reporter/cucumber.rb
@@ -65,6 +65,14 @@ module CI
         @name = (name || "Unnamed feature").split("\n").first
       end
 
+      def before_feature_element(feature_element)
+        @feature_element = feature_element
+      end
+
+      def after_feature_element(feature_element)
+        @feature_element = nil
+      end
+
       def scenario_name(keyword, name, *args)
         @scenario = (name || "Unnamed scenario").split("\n").first
       end

--- a/lib/ci/reporter/cucumber.rb
+++ b/lib/ci/reporter/cucumber.rb
@@ -111,7 +111,7 @@ module CI
         row = table_row # shorthand for table_row
         # check multiple versions of the row and try to find the best fit
 
-        if row.respond_to? :scenario_outline
+        if row.respond_to?(:scenario_outline) && !@header_row
           outline = (row.respond_to? :name)             ? row.name :
                     (row.respond_to? :scenario_outline) ? row.scenario_outline :
                                                           row.to_s

--- a/lib/ci/reporter/cucumber.rb
+++ b/lib/ci/reporter/cucumber.rb
@@ -108,11 +108,8 @@ module CI
       end
 
       def before_table_row(table_row)
-        row = table_row # shorthand for table_row
-        # check multiple versions of the row and try to find the best fit
-
-        if row.respond_to?(:scenario_outline) && !@header_row
-          @test_case = TestCase.new("#@scenario (outline: #{row.name})")
+        if table_row.respond_to?(:scenario_outline) && !@header_row
+          @test_case = TestCase.new("#@scenario (outline: #{table_row.name})")
           @test_case.start
         end
       end

--- a/spec/ci/reporter/cucumber_spec.rb
+++ b/spec/ci/reporter/cucumber_spec.rb
@@ -84,11 +84,19 @@ module CI::Reporter
       let(:test_suite) { double("test_suite", testcases: testcases) }
       let(:cucumber) { new_instance }
       let(:test_case) { double("test_case", start: nil, finish: nil, name: "Step Name") }
+      let(:scenario) { double("scenario") }
       let(:step) { double("step", :status => :passed, name: "Step Name") }
 
       before :each do
         allow(cucumber).to receive(:test_suite).and_return(test_suite)
         allow(CI::Reporter::TestCase).to receive(:new).and_return(test_case)
+        cucumber.before_feature_element(scenario)
+
+        allow(cucumber).to receive(:feature_element_type).and_return(:scenario)
+      end
+
+      after :each do
+        cucumber.after_feature_element(scenario)
       end
 
       context "before steps" do
@@ -231,7 +239,21 @@ module CI::Reporter
         allow(cucumber).to receive(:test_suite).and_return(test_suite)
         allow(CI::Reporter::TestCase).to receive(:new).and_return(test_case)
 
+        cucumber.before_feature_element(scenario_outline)
         cucumber.scenario_name(nil, "Scenario Name")
+
+        allow(cucumber).to receive(:feature_element_type).and_return(:scenario_outline)
+      end
+
+      after :each do
+        cucumber.after_feature_element(scenario_outline)
+      end
+
+      context "before steps" do
+        it "does not create a new test case" do
+          expect(CI::Reporter::TestCase).to_not receive(:new)
+          cucumber.before_steps(step_collection)
+        end
       end
 
       context "processing a data table" do

--- a/spec/ci/reporter/cucumber_spec.rb
+++ b/spec/ci/reporter/cucumber_spec.rb
@@ -218,5 +218,47 @@ module CI::Reporter
         end
       end
     end
+
+    context "inside a scenario outline" do
+      let(:testcases) { [] }
+      let(:test_suite) { double("test_suite", testcases: testcases) }
+      let(:cucumber) { new_instance }
+      let(:test_case) { double("test_case", start: nil, finish: nil, name: "Step Name") }
+      let(:scenario_outline) { double("scenario_outline") }
+      let(:step_collection) { double("step_collection") }
+
+      before :each do
+        allow(cucumber).to receive(:test_suite).and_return(test_suite)
+        allow(CI::Reporter::TestCase).to receive(:new).and_return(test_case)
+
+        cucumber.scenario_name(nil, "Scenario Name")
+      end
+
+      context "processing a data table" do
+        let(:table_row) { double("table_row", name: "Table Row Name") }
+
+        describe "before table row" do
+          it "does not create a new test case" do
+            expect(CI::Reporter::TestCase).to_not receive(:new)
+            cucumber.before_table_row(table_row)
+          end
+        end
+      end
+
+      context "processing an examples table" do
+        let(:table_row) do
+          double("table_row", name: "Table Row Name", scenario_outline: scenario_outline)
+        end
+        let(:expected_test_case_name) { "Scenario Name (outline: Table Row Name)" }
+
+        describe "before table row" do
+          it "creates a new test case" do
+            expect(CI::Reporter::TestCase).to receive(:new).with(expected_test_case_name)
+            cucumber.before_table_row(table_row)
+          end
+        end
+      end
+    end
+
   end
 end


### PR DESCRIPTION
ci_reporter_cucumber was not distinguishing between data tables and tables of examples. The latter should be processed as individual test cases while the former should not.

This update adds that feature.
